### PR TITLE
Rename com.connexta.query to com.connexta.search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
         </license>
     </licenses>
 
-    <groupId>com.connexta.query</groupId>
+    <groupId>com.connexta.search</groupId>
     <artifactId>query-api</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <root.package>com.connexta.query</root.package>
+        <root.package>com.connexta.search</root.package>
 
         <!-- Build properties -->
         <java.version>11</java.version>

--- a/rest/docs/pom.xml
+++ b/rest/docs/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api-rest</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
@@ -23,7 +23,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.connexta.query</groupId>
+            <groupId>com.connexta.search</groupId>
             <artifactId>query-api-rest-specs</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/rest/models/pom.xml
+++ b/rest/models/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api-rest</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
@@ -22,7 +22,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.connexta.query</groupId>
+            <groupId>com.connexta.search</groupId>
             <artifactId>query-api-rest-specs</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>

--- a/rest/servers/pom.xml
+++ b/rest/servers/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api-rest</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>

--- a/rest/servers/spring/pom.xml
+++ b/rest/servers/spring/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api-rest-servers</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
@@ -22,13 +22,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.connexta.query</groupId>
+            <groupId>com.connexta.search</groupId>
             <artifactId>query-api-rest-specs</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>com.connexta.query</groupId>
+            <groupId>com.connexta.search</groupId>
             <artifactId>query-api-rest-models</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/rest/specs/pom.xml
+++ b/rest/specs/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.connexta.query</groupId>
+        <groupId>com.connexta.search</groupId>
         <artifactId>query-api-rest</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
The package name of the artifacts should be the com.connexta.<context>, and the context of query and index is search.